### PR TITLE
Issue #16 strategy object

### DIFF
--- a/app/Commander/InteractsWithCommanders.php
+++ b/app/Commander/InteractsWithCommanders.php
@@ -10,7 +10,13 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 trait InteractsWithCommanders
 {
-    public function createCommander(string $name, float $fund, int $risk, int $botId, $status = Commander::STATUS_CHILL): Model|Builder
+    public function createCommander(
+        string $name,
+        float $fund,
+        int $risk,
+        int $botId = 0,
+        $status = Commander::STATUS_CHILL
+    ): Model|Builder
     {
         return Commander::query()->create([
             'name' => $name,
@@ -21,7 +27,12 @@ trait InteractsWithCommanders
         ]);
     }
 
-    public function findOrCreateCommander(string $name, float $fund, int $risk, int $botId): Model|Builder
+    public function findOrCreateCommander(
+        string $name,
+        float $fund,
+        int $risk,
+        int $botId = 0
+    ): Model|Builder
     {
         $commander = Commander::query()
             ->where('name', $name)

--- a/tests/Unit/CommanderStrategyTest.php
+++ b/tests/Unit/CommanderStrategyTest.php
@@ -8,7 +8,7 @@ use App\Commander\Strategy;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
-class CommanderStrategyTest extends TestCase
+class CommanderStrategy extends TestCase
 {
     use DatabaseTransactions,
         InteractsWithCommanders,
@@ -35,34 +35,43 @@ class CommanderStrategyTest extends TestCase
 
     public function test_it_can_create_a_new_strategy()
     {
-        $strategy = $this->commander->getStrategy();
-
-        $strategy->setBuyMode([
-            'indicator' => 'stochastic',
-            'value' => 'under 20',
-            'resolution' => 240 // 4h timeframe
+        $strategySellTrend = Strategy::create([
+            'resolution' => 240,
+            'value_min' => 80,
+            'value_max' => 100,
+            'type' => 'trend',
+            'side' => 'sell'
         ]);
 
-        $strategy->setBuyTrigger([
-            'indicator' => 'stochastic',
-            'value' => 'under 10',
-            'resolution' => 5 // 5m timeframe
+        $strategyBuyTrend = Strategy::create([
+            'resolution' => 240,
+            'value_min' => 0,
+            'value_max' => 20,
+            'type' => 'trend',
+            'side' => 'sell'
         ]);
 
-        $strategy->setSellMode([
-            'indicator' => 'stochastic',
-            'value' => 'above 80',
-            'resolution' => 240 // 4h timeframe
+        $strategySellTrigger = Strategy::create([
+            'resolution' => 5,
+            'value_min' => 90,
+            'value_max' => 100,
+            'type' => 'trigger',
+            'side' => 'buy'
         ]);
 
-        $strategy->setSellTrigger([
-            'indicator' => 'stochastic',
-            'value' => 'above 90',
-            'resolution' => 5 // 5m timeframe
+        $strategyBuyTrigger = Strategy::create([
+            'resolution' => 5,
+            'value_min' => 0,
+            'value_max' => 10,
+            'type' => 'trigger',
+            'side' => 'buy'
         ]);
 
-        $strategy->create();
-
-        $this->assertInstanceOf(Strategy::class, $strategy);
+        $this->commander
+            ->setSellTrend($strategySellTrend)
+            ->setBuyTrend($strategyBuyTrend)
+            ->setSellTrigger($strategySellTrigger)
+            ->setBuyTrigger($strategyBuyTrigger)
+            ->save();
     }
 }

--- a/tests/Unit/CommanderStrategyTest.php
+++ b/tests/Unit/CommanderStrategyTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Commander\InteractsWithCommanders;
+use App\Models\Commander;
+use App\Commander\Strategy;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class CommanderStrategyTest extends TestCase
+{
+    use DatabaseTransactions,
+        InteractsWithCommanders,
+        InteractsWithTradingSeeds;
+
+    protected Commander $commander;
+
+    /** @noinspection PhpFieldAssignmentTypeMismatchInspection */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->commander = $this->createCommander(
+            'Commander With Strategy',
+            1000,
+            1
+        );
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function test_it_can_create_a_new_strategy()
+    {
+        $strategy = $this->commander->getStrategy();
+
+        $strategy->setBuyMode([
+            'indicator' => 'stochastic',
+            'value' => 'under 20',
+            'resolution' => 240 // 4h timeframe
+        ]);
+
+        $strategy->setBuyTrigger([
+            'indicator' => 'stochastic',
+            'value' => 'under 10',
+            'resolution' => 5 // 5m timeframe
+        ]);
+
+        $strategy->setSellMode([
+            'indicator' => 'stochastic',
+            'value' => 'above 80',
+            'resolution' => 240 // 4h timeframe
+        ]);
+
+        $strategy->setSellTrigger([
+            'indicator' => 'stochastic',
+            'value' => 'above 90',
+            'resolution' => 5 // 5m timeframe
+        ]);
+
+        $strategy->create();
+
+        $this->assertInstanceOf(Strategy::class, $strategy);
+    }
+}


### PR DESCRIPTION
PR for issue #16 

## WIP: Add testing for strategy object

I'm brainstorming on how to organise the Strategy object for Commander. Each commander need 2 major points to get a Commander to work:

1. When Commander should start buy/sell mode? For example when an indicator named `stochastic` go above 80 on timeframe 4 hours (resolution 240) -> turn on sell mode.
2. Based on (1), when a Commander should execute a trade? For example, Commander should execute a sell trade when an indicator named `stochastic` go above 90 on timeframe 5 minutes (resolution 5)